### PR TITLE
change input field on node name edit to close when it's unfocused

### DIFF
--- a/src/client/src/components/Graph.tsx
+++ b/src/client/src/components/Graph.tsx
@@ -229,6 +229,14 @@ export const Graph = (props: GraphProps): JSX.Element => {
                     project_id: selectedProject.id,
                 };
 
+                if (!data.label) {
+                    setElements((els) => {
+                        return els.filter((e) => e.id !== 'TEMP');
+                    });
+
+                    return;
+                }
+
                 const returnId = await nodeService.sendNode(n);
 
                 if (returnId) {

--- a/src/client/src/components/NodeEdit.tsx
+++ b/src/client/src/components/NodeEdit.tsx
@@ -32,6 +32,7 @@ export const NodeEdit = (props: NodeEditProps): JSX.Element => {
                     onChange={(e) => {
                         setnodeName(e.target.value);
                     }}
+                    onBlur={handleSubmit}
                 />
             </form>
         </div>


### PR DESCRIPTION
If creating a new node (with ctrl+click), and name is empty, unfocus deletes the new node visually (since it never actually existed). 
Escape does not unfocus the input fields for some reason. 