### PR TITLE
add ability to unfocus node creation with escape

### DIFF
--- a/src/client/src/components/Graph.tsx
+++ b/src/client/src/components/Graph.tsx
@@ -167,15 +167,23 @@ export const Graph = (props: GraphProps): JSX.Element => {
         }
     };
 
+    const [lastCanceledName, setLastCanceledName] = useState('');
+
+    const removeTempNode = () => {
+        setElements((els) => {
+            return els.filter((e) => e.id !== 'TEMP');
+        });
+    }
+
     const onNodeNamingDone = async (label: string, node: Node) => {
         if (selectedProject) {
             if (!label) {
-                setElements((els) => {
-                    return els.filter((e) => e.id !== 'TEMP');
-                });
+                removeTempNode();
 
                 return;
             }
+
+            setLastCanceledName('');
 
             const data: INode = {
                 ...basicNode,
@@ -190,6 +198,11 @@ export const Graph = (props: GraphProps): JSX.Element => {
             props.sendNode(data, node, setElements);
         }
     };
+
+    const onNodeNamingCancel = (canceledName: string) => {
+        setLastCanceledName(canceledName);
+        removeTempNode();
+    }
 
     // handle what happens on mousepress press
     const handleMousePress = (event: MouseEvent) => {
@@ -218,9 +231,11 @@ export const Graph = (props: GraphProps): JSX.Element => {
 
             unnamedNode.data.label = (
                 <NodeNaming
-                    onNodeNamingDone={async (label) =>
-                        onNodeNamingDone(label, unnamedNode)
+                    initialName={lastCanceledName}
+                    onNodeNamingDone={async (name) =>
+                        onNodeNamingDone(name, unnamedNode)
                     }
+                    onCancel={onNodeNamingCancel}
                 />
             );
 

--- a/src/client/src/components/NodeNaming.tsx
+++ b/src/client/src/components/NodeNaming.tsx
@@ -1,15 +1,23 @@
-import React, { FormEvent, useState } from 'react';
+import { FormEvent, useState, KeyboardEvent } from 'react';
 
 interface NodeNamingProps {
-    onNodeNamingDone: (label: string) => void;
+    initialName?: string;
+    onNodeNamingDone: (name: string) => void;
+    onCancel: (name: string) => void;
 }
 
 export const NodeNaming = (props: NodeNamingProps): JSX.Element => {
-    const [nodeName, setnodeName] = useState('');
+    const [nodeName, setnodeName] = useState(props.initialName || '');
 
     const handleSubmit = (event: FormEvent) => {
         props.onNodeNamingDone(nodeName);
         event.preventDefault();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Escape') {
+            props.onCancel(nodeName);
+        }
     };
 
     return (
@@ -20,10 +28,9 @@ export const NodeNaming = (props: NodeNamingProps): JSX.Element => {
                     style={{ width: '100%' }}
                     type="text"
                     value={nodeName}
-                    onChange={(e) => {
-                        setnodeName(e.target.value);
-                    }}
+                    onChange={(e) => setnodeName(e.target.value)}
                     onBlur={() => props.onNodeNamingDone(nodeName)}
+                    onKeyDown={handleKeyDown}
                 />
             </form>
         </div>

--- a/src/client/src/tests/components/nodeNaming.test.tsx
+++ b/src/client/src/tests/components/nodeNaming.test.tsx
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { NodeNaming } from '../../components/NodeNaming';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('<NodeNaming>', () => {
+    const getComponent = (
+        onNodeNamingDone: (name: string) => void,
+        onCancel: (name: string) => void,
+        initialName?: string
+    ) => {
+        return render(
+            <NodeNaming
+                initialName={initialName}
+                onNodeNamingDone={onNodeNamingDone}
+                onCancel={onCancel}
+            />
+        );
+    };
+
+    const testInitialName = 'test initial name';
+
+    test('should have one input field', () => {
+        const nodeNaming = getComponent(
+            () => {},
+            () => {}
+        );
+
+        expect(nodeNaming.container.querySelectorAll('input')).toHaveLength(1);
+    });
+
+    test('input field should be pre-populated with the initial name', () => {
+        const nodeNaming = getComponent(
+            () => {},
+            () => {},
+            testInitialName
+        );
+
+        expect(nodeNaming.container.querySelector('input')!.value).toBe(
+            testInitialName
+        );
+    });
+
+    test('should call onNodeNamingDone with the correct string when user writes to input field and presses enter', () => {
+        const testNodeNamingDone = (name: string) =>
+            expect(name).toBe(testInitialName);
+
+        const nodeNaming = getComponent(testNodeNamingDone, () => {});
+
+        fireEvent.change(nodeNaming.container.querySelector('input')!, {
+            target: { value: testInitialName },
+        });
+
+        fireEvent.submit(nodeNaming.container.querySelector('input')!);
+
+        expect(testNodeNamingDone).toBeCalled;
+    });
+
+    test('should call onNodeNamingDone with the correct string when user writes to input field and unfocuses', () => {
+        const testNodeNamingDone = (name: string) =>
+            expect(name).toBe(testInitialName);
+
+        const nodeNaming = getComponent(testNodeNamingDone, () => {});
+
+        fireEvent.change(nodeNaming.container.querySelector('input')!, {
+            target: { value: testInitialName },
+        });
+
+        fireEvent.blur(nodeNaming.container.querySelector('input')!);
+
+        expect(testNodeNamingDone).toBeCalled;
+    });
+
+    test('should call onCancel with the correct string when user writes to input field and presses escape', () => {
+        const testCancel = (name: string) => expect(name).toBe(testInitialName);
+
+        const nodeNaming = getComponent(() => {}, testCancel);
+
+        fireEvent.change(nodeNaming.container.querySelector('input')!, {
+            target: { value: testInitialName },
+        });
+
+        fireEvent.keyDown(nodeNaming.container.querySelector('input')!, {
+            key: 'Escape',
+        });
+
+        expect(testCancel).toBeCalled;
+    });
+});


### PR DESCRIPTION
Creating nodes now works like creating tickets in Trello. 

write + enter => node created with name
write + click off => node created with name
write + esc => node not created, name saved and pre-filled next time a node is created