### PR TITLE
Remove description requirement (fixes bulk edit)

### DIFF
--- a/src/server/route/routes/node.ts
+++ b/src/server/route/routes/node.ts
@@ -16,8 +16,7 @@ const nodeCheck = (node: INode): boolean => {
             node.hasOwnProperty('x') &&
             // eslint-disable-next-line no-prototype-builtins
             node.hasOwnProperty('y') &&
-            node.project_id &&
-            node.description
+            node.project_id
     );
 };
 

--- a/src/server/route/routes/node.ts
+++ b/src/server/route/routes/node.ts
@@ -163,9 +163,7 @@ router
             array = data;
         } else {
             if (!nodeCheck(data)) {
-                return res
-                    .status(403)
-                    .json({ message: 'Invalid node' });
+                return res.status(403).json({ message: 'Invalid node' });
             }
 
             const permissions = await checkProjectPermission(

--- a/src/server/route/routes/node.ts
+++ b/src/server/route/routes/node.ts
@@ -152,7 +152,7 @@ router
             ) {
                 return res
                     .status(403)
-                    .json({ message: 'Invalid node or multiple projectIds' });
+                    .json({ message: 'Invalid nodes or multiple projectIds' });
             }
 
             const permissions = await checkProjectPermission(req, projectId);
@@ -162,6 +162,12 @@ router
 
             array = data;
         } else {
+            if (!nodeCheck(data)) {
+                return res
+                    .status(403)
+                    .json({ message: 'Invalid node' });
+            }
+
             const permissions = await checkProjectPermission(
                 req,
                 data.project_id


### PR DESCRIPTION
Fixes the bug that caused the automatic ordering to break. Basically the description field was added later which resulted in most nodes having an empty string description. This made it impossible to update these nodes because an empty string is considered falsy