### PR TITLE
Check permissions for all routes

### DIFF
--- a/src/client/src/pages/GraphPage.tsx
+++ b/src/client/src/pages/GraphPage.tsx
@@ -6,6 +6,7 @@ import {
     IEdge,
     INode,
     IProject,
+    NoPermission,
     ProjectPermissions,
     RootState,
     UserData,
@@ -53,9 +54,12 @@ export const GraphPage = (): JSX.Element => {
     const [selectedProject, setSelectedProject] = useState<
         IProject | undefined
     >(undefined);
-    const [permissions, setPermissions] = useState<ProjectPermissions>({
+    const [permissions, setPermissions] = useState<
+        NoPermission | ProjectPermissions
+    >({
         view: false,
         edit: false,
+        projectId: undefined,
     });
     const [members, setMembers] = useState<UserData[]>([]);
     const [show, setShow] = useState(false);
@@ -97,7 +101,7 @@ export const GraphPage = (): JSX.Element => {
                 .then((permissions) => setPermissions(permissions))
                 .finally(() => setIsLoadingPermissions(false));
         } else {
-            setPermissions({ view: false, edit: false });
+            setPermissions({ view: false, edit: false, projectId: undefined });
         }
     }, [selectedProject]);
 

--- a/src/client/src/services/projectService.ts
+++ b/src/client/src/services/projectService.ts
@@ -1,5 +1,10 @@
 import axios from 'axios';
-import { IProject, ProjectPermissions, UserData } from '../../../../types';
+import {
+    IProject,
+    NoPermission,
+    ProjectPermissions,
+    UserData,
+} from '../../../../types';
 import { axiosWrapper } from './axiosWrapper';
 import { getAuthConfig } from './userService';
 export const baseUrl = '/api/project';
@@ -20,14 +25,14 @@ const getProject = async (projectId: number): Promise<IProject | undefined> => {
 
 const getProjectPermissions = async (
     projectId: number
-): Promise<ProjectPermissions> => {
+): Promise<ProjectPermissions | NoPermission> => {
     const project = await axiosWrapper(
-        axios.get<ProjectPermissions>(
+        axios.get<ProjectPermissions | NoPermission>(
             `${baseUrl}/${projectId}/permission`,
             getAuthConfig()
         )
     );
-    return project || { view: false, edit: false };
+    return project || { view: false, edit: false, projectId: undefined };
 };
 
 const sendProject = async (project: IProject): Promise<number | undefined> => {

--- a/src/server/dbConfigs.ts
+++ b/src/server/dbConfigs.ts
@@ -1,5 +1,5 @@
 import { getConfig } from './configs';
-import { Pool, QueryConfig } from 'pg'; //PoolConfig was unused
+import { Pool, QueryConfig, QueryResultRow } from 'pg'; //PoolConfig was unused
 import { migrate } from 'postgres-migrations';
 import { logger } from './helper/logging';
 
@@ -11,7 +11,10 @@ export class Database {
     //handled in another way. Need to find at a later time whether it can be given a type.
 
     //eslint-disable-next-line @typescript-eslint/no-explicit-any -- /* eslint-disable ... */
-    async query(text: string | QueryConfig<any>, params?: unknown[]) {
+    async query<R extends QueryResultRow = any, I extends any[] = any[]>(
+        text: string | QueryConfig<any>,
+        params?: unknown[]
+    ) {
         if (this._waiting) {
             await this._waiting;
         }
@@ -20,7 +23,7 @@ export class Database {
         //console.log("Text: ", text)
         //console.log("Params: ", params)
         const pool = await this.getPool();
-        const res = await pool.query(text, params);
+        const res = await pool.query<R, I>(text, params as any);
         const duration = Date.now() - start;
         if (process.env.NODE_ENV === 'development') {
             logger.debug({

--- a/src/server/helper/permissionHelper.ts
+++ b/src/server/helper/permissionHelper.ts
@@ -1,17 +1,27 @@
 import { db } from '../dbConfigs';
 import { Request } from 'express';
-import { ProjectPermissions } from '../../../types';
+import { ProjectPermissions, NoPermission, IProject } from '../../../types';
 
-export const checkProjectPermission = async (
+export const noPermission: NoPermission = {
+    projectId: undefined,
+    view: false,
+    edit: false,
+};
+
+export const checkProjectPermissionByProjectId = async (
     req: Request,
-    project_id: number
-): Promise<ProjectPermissions> => {
-    const q = await db.query('SELECT * FROM project WHERE id = $1', [
-        project_id,
+    projectId: number | unknown
+): Promise<ProjectPermissions | NoPermission> => {
+    if (typeof projectId !== 'number') {
+        return noPermission;
+    }
+
+    const q = await db.query<IProject>('SELECT * FROM project WHERE id = $1', [
+        projectId,
     ]);
 
     if (!q.rowCount) {
-        throw Error('invalid project');
+        return noPermission;
     }
 
     const project = q.rows[0];
@@ -19,16 +29,88 @@ export const checkProjectPermission = async (
     if (req.token && req.user) {
         const userId = req.user.id;
 
-        const belongsToProject = await userMemberOfProject(userId, project_id);
+        const belongsToProject = await userMemberOfProject(userId, projectId);
 
         if (!project.public_view) {
-            return { view: belongsToProject, edit: belongsToProject };
+            return {
+                view: belongsToProject,
+                edit: belongsToProject,
+                projectId: project.id,
+            };
         } else if (!project.public_edit) {
-            return { view: true, edit: belongsToProject };
+            return {
+                view: true,
+                edit: belongsToProject,
+                projectId: project.id,
+            };
         }
     }
 
-    return { view: project.public_view, edit: project.public_edit };
+    return {
+        view: project.public_view,
+        edit: project.public_edit,
+        projectId: project.id,
+    };
+};
+
+export const checkProjectPermissionByNodeId = async (
+    req: Request,
+    nodeId: number | unknown
+): Promise<ProjectPermissions | NoPermission> => {
+    if (typeof nodeId !== 'number') {
+        return noPermission;
+    }
+    const q = await db.query<{ project_id: number }>(
+        'SELECT project_id FROM node WHERE id = $1',
+        [nodeId]
+    );
+
+    if (!q.rowCount) {
+        return noPermission;
+    }
+
+    return checkProjectPermissionByProjectId(req, q.rows[0].project_id);
+};
+
+export const checkProjectPermissionByEdgeId = async (
+    req: Request,
+    sourceNodeId: number | unknown,
+    targetNodeId: number | unknown
+): Promise<ProjectPermissions | NoPermission> => {
+    if (typeof sourceNodeId !== 'number' || typeof targetNodeId !== 'number') {
+        return noPermission;
+    }
+
+    const q = await db.query<{ project_id: number }>(
+        'SELECT project_id FROM edge WHERE source_id = $1 AND target_id = $2',
+        [sourceNodeId, targetNodeId]
+    );
+
+    if (!q.rowCount) {
+        return noPermission;
+    }
+
+    return checkProjectPermissionByProjectId(req, q.rows[0].project_id);
+};
+
+export const checkProjectPermissionByTagId = async (
+    req: Request,
+    tagId: number | unknown
+): Promise<ProjectPermissions | NoPermission> => {
+    if (typeof tagId !== 'number') {
+        return noPermission;
+    }
+
+    const q = await db.query<{ project_id: number }>(
+        'SELECT project_id FROM tag WHERE id = $1',
+        [tagId]
+    );
+
+    if (!q.rowCount) {
+        return noPermission;
+    }
+
+    return checkProjectPermissionByProjectId(req, q.rows[0].project_id);
 };
 
 export const userMemberOfProject = async (

--- a/src/server/route/routes/assignment.ts
+++ b/src/server/route/routes/assignment.ts
@@ -1,7 +1,7 @@
 import { router } from '../router';
 import { Request, Response } from 'express';
 import { db } from '../../dbConfigs';
-import { checkProjectPermission } from '../../helper/permissionHelper';
+import { checkProjectPermissionByNodeId } from '../../helper/permissionHelper';
 
 const assignmentCheck = async (
     req: Request,
@@ -15,8 +15,18 @@ const assignmentCheck = async (
         return;
     }
 
-    //check user id
+    //check permissions
+    const { edit, projectId } = await checkProjectPermissionByNodeId(
+        req,
+        nodeId
+    );
 
+    if (!projectId || !edit) {
+        res.status(401).json({ message: 'No permission' });
+        return;
+    }
+
+    //check user id
     const userQuery = await db.query(
         'SELECT COUNT(*) FROM users WHERE id = $1;',
         [userId]
@@ -27,31 +37,7 @@ const assignmentCheck = async (
         return;
     }
 
-    //get project id
-
-    const projectIdQuery = await db.query(
-        'SELECT project_id FROM node WHERE id = $1;',
-        [nodeId]
-    );
-
-    if (!projectIdQuery.rowCount) {
-        res.status(403).json({ message: 'Invalid node id' });
-        return;
-    }
-
-    const projectId: number = projectIdQuery.rows[0].project_id;
-
-    //check permissions
-
-    const permissions = await checkProjectPermission(req, projectId);
-
-    if (!permissions.edit) {
-        res.status(401).json({ message: 'No permission' });
-        return;
-    }
-
     //return user, node and project ids
-
     return [userId, nodeId, projectId];
 };
 
@@ -138,30 +124,19 @@ router.route('/assignment/:nodeId').get(async (req: Request, res: Response) => {
         return;
     }
 
-    const projectIdQuery = await db.query(
-        'SELECT project_id FROM node WHERE id = $1;',
-        [nodeId]
-    );
-
-    if (!projectIdQuery.rowCount) {
-        res.status(403).json({ message: 'Invalid node id' });
-        return;
-    }
-
-    const projectId: number = projectIdQuery.rows[0].project_id;
-    const permissions = await checkProjectPermission(req, projectId);
-
-    if (!permissions.view) {
+    //check permissions
+    const { view } = await checkProjectPermissionByNodeId(req, nodeId);
+    if (!view) {
         res.status(401).json({ message: 'No permission' });
         return;
     }
 
-    const asd = await db.query(
+    const result = await db.query(
         'SELECT username, email, id FROM users WHERE id IN (SELECT users_id FROM users__node WHERE node_id = $1)',
         [nodeId]
     );
 
-    res.status(200).json(asd.rows);
+    res.status(200).json(result.rows);
 });
 
 export { router as assignment };

--- a/src/server/route/routes/project.ts
+++ b/src/server/route/routes/project.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { IProject, UserData } from '../../../../types';
 //import {IError} from '../../domain/IError';
 import { db } from '../../dbConfigs';
-import { checkProjectPermission } from '../../helper/permissionHelper';
+import { checkProjectPermissionByProjectId } from '../../helper/permissionHelper';
 
 /* let projects: Array<IProject> = [{id: '1', name: 'test'}]; */
 
@@ -18,15 +18,16 @@ import { checkProjectPermission } from '../../helper/permissionHelper';
 router
     .route('/project/:id')
     .get(async (req: Request, res: Response) => {
-        const project_id = parseInt(req.params.id);
+        const { view, projectId } = await checkProjectPermissionByProjectId(
+            req,
+            parseInt(req.params.id)
+        );
 
-        const permissions = await checkProjectPermission(req, project_id);
-
-        if (!permissions.view) {
+        if (!projectId || !view) {
             return res.status(401).json({ message: 'No permission' });
         }
         const q = await db.query('SELECT * FROM project WHERE id = $1', [
-            project_id,
+            projectId,
         ]);
         res.json(q.rows[0]);
     })
@@ -39,26 +40,21 @@ router
      * @response 401 - Unauthorized
      */
     .delete(async (req: Request, res: Response) => {
-        if (!req.token || !req.user) {
-            return res.status(401).json({ error: 'token missing or invalid' });
+        const { view, projectId } = await checkProjectPermissionByProjectId(
+            req,
+            parseInt(req.params.id)
+        );
+
+        if (!projectId || !view) {
+            return res.status(401).json({ message: 'No permission' });
         }
-        const id = req.params.id;
-        const ownerId = req.user.id;
+        const ownerId = req.user?.id;
 
         const q = await db.query(
             'DELETE FROM project WHERE id = $1 AND owner_id = $2',
-            [id, ownerId]
+            [projectId, ownerId]
         );
         res.status(200).json(q);
-        //the latter part is only for testing with array
-        /* const idx = projects.findIndex( p => p.id === id );
-        if(idx >= 0){
-            console.log('deleting project: ', projects[idx]);
-            projects.splice(idx, 1);
-            res.status(200).json({ message: 'deleted project'})
-        } else {
-            console.log('could not find project with id: ', id);
-        } */
     });
 
 /**
@@ -73,7 +69,10 @@ router
     .get(async (req: Request, res: Response) => {
         const project_id = parseInt(req.params.id);
 
-        const permissions = await checkProjectPermission(req, project_id);
+        const permissions = await checkProjectPermissionByProjectId(
+            req,
+            project_id
+        );
         res.json(permissions);
     });
 
@@ -101,8 +100,6 @@ router
             [userId]
         );
         res.json(q.rows);
-        /* console.log('projects: ', projects);
-        res.json(projects); */
     })
     /**
      * POST /api/project
@@ -155,8 +152,6 @@ router
             );
             client.query('COMMIT');
             res.status(200).json({ id: projectId });
-            /* console.log('adding project: ', project);
-            projects.push(project) */
         } catch (e) {
             // eslint-disable-next-line no-console
             console.log('Invalid project', e);
@@ -177,21 +172,20 @@ router
      *
      */
     .put(async (req: Request, res: Response) => {
-        if (!req.token || !req.user) {
-            return res.status(401).json({ error: 'token missing or invalid' });
-        }
-
         const p: IProject = req.body;
 
-        const permissions = await checkProjectPermission(req, p.id);
+        const { projectId, edit } = await checkProjectPermissionByProjectId(
+            req,
+            p.id
+        );
 
-        if (!permissions.view) {
+        if (!projectId || !edit) {
             return res.status(401).json({ message: 'No permission' });
         }
 
         req.logger.info({
             message: 'Updating project details',
-            projectId: p.id,
+            projectId,
         });
 
         const q = await db.query(
@@ -201,14 +195,11 @@ router
                 p.description,
                 p.public_view,
                 p.public_edit,
-                p.id,
+                projectId,
                 p.owner_id,
             ]
         );
         res.status(200).json(q);
-        /* const idx = projects.findIndex( pr => pr.id === p.id );
-        projects[idx] = p;
-        res.status(200).json({ message: 'project updated'}); */
     })
     .delete(async (req: Request, res: Response) => {
         res.status(404).json({ message: 'Not implemented' });
@@ -225,10 +216,12 @@ router
 router
     .route('/project/:id/members')
     .get(async (req: Request, res: Response) => {
-        const projectId = parseInt(req.params.id);
-        const permissions = await checkProjectPermission(req, projectId);
+        const { projectId, view } = await checkProjectPermissionByProjectId(
+            req,
+            parseInt(req.params.id)
+        );
 
-        if (!permissions.view) {
+        if (!projectId || !view) {
             return res.status(401).json({ message: 'No permission' });
         }
 
@@ -254,13 +247,15 @@ router
      * @response 401 - Unauthorized
      */
     .post(async (req: Request, res: Response) => {
-        const projectId = parseInt(req.params.id);
-        const permissions = await checkProjectPermission(req, projectId);
+        const { edit, projectId } = await checkProjectPermissionByProjectId(
+            req,
+            parseInt(req.params.id)
+        );
 
         const invite: string = req.body.member;
 
         // Test whether inviter belongs in project
-        if (!permissions.edit) {
+        if (!edit) {
             return res.status(401).json({ message: 'No permission' });
         }
 
@@ -275,7 +270,7 @@ router
 
             req.logger.info({
                 message: 'Adding user to project',
-                projectId: projectId,
+                projectId,
                 addedUserId: user.id,
             });
 
@@ -302,12 +297,14 @@ router
 router
     .route('/project/:pid/members/:uid')
     .delete(async (req: Request, res: Response) => {
-        const projectId = parseInt(req.params.pid);
         const userId = parseInt(req.params.uid);
-        const permissions = await checkProjectPermission(req, projectId);
+        const { projectId, edit } = await checkProjectPermissionByProjectId(
+            req,
+            parseInt(req.params.pid)
+        );
 
         // Test whether inviter belongs in project
-        if (!permissions.edit) {
+        if (!edit) {
             return res.status(401).json({ message: 'No permission' });
         }
 

--- a/src/server/route/routes/tag.ts
+++ b/src/server/route/routes/tag.ts
@@ -2,12 +2,23 @@ import { router } from '../router';
 import { Request, Response } from 'express';
 import { ITag } from '../../../../types';
 import { db } from '../../dbConfigs';
+import {
+    checkProjectPermissionByProjectId,
+    checkProjectPermissionByTagId,
+} from '../../helper/permissionHelper';
 
 router.route('/tag/proj/:proj').get(async (req: Request, res: Response) => {
-    const proj_id = req.params.proj;
+    const { view, projectId } = await checkProjectPermissionByProjectId(
+        req,
+        parseInt(req.params.proj)
+    );
+
+    if (!projectId || !view) {
+        return res.status(401).json({ message: 'No permission' });
+    }
 
     const q = await db.query('SELECT * FROM tag WHERE project_id = $1', [
-        proj_id,
+        projectId,
     ]);
     res.json(q.rows);
 });
@@ -15,23 +26,32 @@ router.route('/tag/proj/:proj').get(async (req: Request, res: Response) => {
 router
     .route('/tag')
     .get(async (req: Request, res: Response) => {
+        // todo: check permissions?
         const q = await db.query('SELECT * FROM tag', []);
         res.json(q.rows);
     })
     .post(async (req: Request, res: Response) => {
         const tag: ITag = req.body;
 
+        const { view, projectId } = await checkProjectPermissionByProjectId(
+            req,
+            tag.project_id
+        );
+
+        if (!projectId || !view) {
+            return res.status(401).json({ message: 'No permission' });
+        }
+
         try {
             req.logger.info({
                 message: 'Adding tag to node',
-                projectId: tag.project_id,
+                projectId,
                 label: tag.label,
             });
 
             const q = await db.query(
-                // ignores tag.id when inserting into table
                 'INSERT INTO tag (label, color, project_id) VALUES ($1, $2, $3) RETURNING id',
-                [tag.label, tag.color, tag.project_id]
+                [tag.label, tag.color, projectId]
             );
             res.status(200).json(q);
         } catch (e) {
@@ -42,24 +62,42 @@ router
     .put(async (req: Request, res: Response) => {
         const t: ITag = req.body;
 
+        const { edit, projectId } = await checkProjectPermissionByTagId(
+            req,
+            t.id
+        );
+
+        if (!projectId || !edit) {
+            return res.status(401).json({ message: 'No permission' });
+        }
+
         req.logger.info({
             message: 'Updating tag',
-            projectId: t.project_id,
+            projectId,
             tagId: t.id,
         });
 
         const q = await db.query(
             'UPDATE tag SET label = $1, color = $2 WHERE id = $3 AND project_id = $4',
-            [t.label, t.color, t.id, t.project_id]
+            [t.label, t.color, t.id, projectId]
         );
         res.status(200).json(q);
     })
     .delete(async (req: Request, res: Response) => {
         const t: ITag = req.body;
 
+        const { edit, projectId } = await checkProjectPermissionByTagId(
+            req,
+            t.id
+        );
+
+        if (!projectId || !edit) {
+            return res.status(401).json({ message: 'No permission' });
+        }
+
         req.logger.info({
             message: 'Deleting tag',
-            projectId: t.project_id,
+            projectId: projectId,
             tagId: t.id,
         });
 

--- a/src/server/tests/assignment.test.ts
+++ b/src/server/tests/assignment.test.ts
@@ -95,7 +95,7 @@ describe('assignment', () => {
                         user.id
                     }`
                 )
-                .expect(403);
+                .expect(401);
 
             const q = await db.query('SELECT * FROM users__node');
 
@@ -163,7 +163,7 @@ describe('assignment', () => {
                         user.id
                     }`
                 )
-                .expect(403);
+                .expect(401);
 
             const q = await db.query('SELECT * FROM users__node');
 

--- a/src/server/tests/edge.test.ts
+++ b/src/server/tests/edge.test.ts
@@ -170,7 +170,7 @@ describe('Edge', () => {
             };
             await api
                 .delete(`${baseUrl}/${e.source_id}/${e.target_id}`)
-                .expect(403);
+                .expect(401);
         });
     });
 });

--- a/src/server/tests/project.test.ts
+++ b/src/server/tests/project.test.ts
@@ -168,8 +168,8 @@ describe('Projects', () => {
             };
             await api
                 .delete(`${baseUrl}/${p.id}`)
-                .set('X-Depsee-Auth', `bearer ${token}`)
-                .expect(200);
+                .set('Authorization', `bearer ${token}`)
+                .expect(401);
         });
     });
 

--- a/types.ts
+++ b/types.ts
@@ -86,8 +86,15 @@ export interface ToolbarProps {
 }
 
 export interface ProjectPermissions {
+    projectId: number;
     view: boolean;
     edit: boolean;
+}
+
+export interface NoPermission {
+    projectId: undefined;
+    view: false;
+    edit: false;
 }
 
 export interface ITag {


### PR DESCRIPTION
A bunch of routes were missing proper permission checks, this at least attempts to do that.
Essentially:
- All GET requests should check for the view permission
- All POST/PUT/DELETE requests should check for the edit permission
- We can't trust the client to send a nodeId that matches the projectId, so handle those appropriately