### PR TITLE
Use left-right edge positions as default

### DIFF
--- a/src/client/src/components/Graph.tsx
+++ b/src/client/src/components/Graph.tsx
@@ -108,6 +108,7 @@ export const Graph = (props: GraphProps): JSX.Element => {
                 '--connect-btn-bckg-color',
                 '#310062'
             );
+            document.body.style.setProperty('--right-handle-size', '100%');
             document.body.style.setProperty('--bottom-handle-size', '100%');
             document.body.style.setProperty(
                 '--source-handle-border-radius',
@@ -122,6 +123,7 @@ export const Graph = (props: GraphProps): JSX.Element => {
                 '--connect-btn-bckg-color',
                 '#686559'
             );
+            document.body.style.setProperty('--right-handle-size', '6px');
             document.body.style.setProperty('--bottom-handle-size', '6px');
             document.body.style.setProperty(
                 '--source-handle-border-radius',
@@ -331,6 +333,7 @@ export const Graph = (props: GraphProps): JSX.Element => {
 
     const onConnectStart = () => {
         document.body.style.setProperty('--top-handle-size', '100%');
+        document.body.style.setProperty('--left-handle-size', '100%');
         document.body.style.setProperty('--source-handle-visibility', 'none');
         document.body.style.setProperty('--target-handle-border-radius', '0');
         document.body.style.setProperty('--target-handle-opacity', '0');
@@ -338,6 +341,7 @@ export const Graph = (props: GraphProps): JSX.Element => {
 
     const onConnectEnd = () => {
         document.body.style.setProperty('--top-handle-size', '6px');
+        document.body.style.setProperty('--left-handle-size', '6px');
         document.body.style.setProperty('--source-handle-visibility', 'block');
         document.body.style.setProperty(
             '--target-handle-border-radius',

--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -48,7 +48,9 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     line-height: 1.5;
+    --left-handle-size: 6px;
     --top-handle-size: 6px;
+    --right-handle-size: 6px;
     --bottom-handle-size: 6px;
     --source-handle-visibility: block;
     --target-handle-border-radius: 100%;
@@ -253,12 +255,11 @@ code {
     color: #eeefff;
 }
 
-.react-flow__handle-bottom {
-    width: var(--bottom-handle-size) !important;
-    height: var(--bottom-handle-size) !important;
-    display: var(--source-handle-visibility) !important;
-    border-radius: var(--source-handle-border-radius) !important;
-    opacity: var(--source-handle-opacity) !important;
+.react-flow__handle-left {
+    width: var(--left-handle-size) !important;
+    height: var(--left-handle-size) !important;
+    border-radius: var(--target-handle-border-radius) !important;
+    opacity: var(--target-handle-opacity) !important;
 }
 
 .react-flow__handle-top {
@@ -267,6 +268,23 @@ code {
     border-radius: var(--target-handle-border-radius) !important;
     opacity: var(--target-handle-opacity) !important;
 }
+
+.react-flow__handle-right {
+    width: var(--right-handle-size) !important;
+    height: var(--right-handle-size) !important;
+    display: var(--source-handle-visibility) !important;
+    border-radius: var(--source-handle-border-radius) !important;
+    opacity: var(--source-handle-opacity) !important;
+}
+
+.react-flow__handle-bottom {
+    width: var(--bottom-handle-size) !important;
+    height: var(--bottom-handle-size) !important;
+    display: var(--source-handle-visibility) !important;
+    border-radius: var(--source-handle-border-radius) !important;
+    opacity: var(--source-handle-opacity) !important;
+}
+
 .react-flow__edge-path {
     transition: var(--edge-transition) !important;
 }

--- a/src/client/src/pages/GraphPage.tsx
+++ b/src/client/src/pages/GraphPage.tsx
@@ -18,6 +18,7 @@ import {
     isEdge,
     isNode,
     Node,
+    Position,
 } from 'react-flow-renderer';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router';
@@ -129,6 +130,8 @@ export const GraphPage = (): JSX.Element => {
                     type: DefaultNodeType,
                     data: n,
                     position: { x: n.x, y: n.y },
+                    sourcePosition: Position.Right,
+                    targetPosition: Position.Left,
                 }));
                 // Edge Types: 'default' | 'step' | 'smoothstep' | 'straight'
                 const edgeElements: Elements = edges.map((e) => ({


### PR DESCRIPTION
Since the horizontal layout works a lot better than the other options,
let's also give an sensible default for the edge connector position.