### PR TITLE
Remove sidebar labels

### DIFF
--- a/src/client/src/App.css
+++ b/src/client/src/App.css
@@ -120,3 +120,8 @@
     justify-content: center;
     margin-top: 75px;
 }
+
+#edge-detail-arrow {
+    margin-bottom: 10px;
+    margin-left: 10px;
+}

--- a/src/client/src/App.css
+++ b/src/client/src/App.css
@@ -122,7 +122,7 @@
 }
 
 .assigned-users-list {
-    list-style-type:none;
+    list-style-type: none;
     padding: 0 1em;
     border-left: 2px solid #eeefff;
 }

--- a/src/client/src/App.css
+++ b/src/client/src/App.css
@@ -121,6 +121,12 @@
     margin-top: 75px;
 }
 
+.assigned-users-list {
+    list-style-type:none;
+    padding: 0 1em;
+    border-left: 2px solid #eeefff;
+}
+
 #edge-detail-arrow {
     margin-bottom: 10px;
     margin-left: 10px;

--- a/src/client/src/App.css
+++ b/src/client/src/App.css
@@ -132,8 +132,8 @@
 #edge-detail-arrow {
     margin-bottom: 10px;
     margin-left: 10px;
+}
 
 .unhighlited-node {
     background-color: var(--unhighlited-node-background-color);
-
 }

--- a/src/client/src/components/AssignedUsers.tsx
+++ b/src/client/src/components/AssignedUsers.tsx
@@ -30,9 +30,12 @@ export const AssignedUsers = (props: assignedUsersProps): JSX.Element => {
             {isLoading ? (
                 <Spinner animation="border" />
             ) : (
-                <ul className='assigned-users-list'>
+                <ul className="assigned-users-list">
                     {assigned.map((user) => (
-                        <li><BsFillPersonFill />{' ' + user.username}</li>
+                        <li>
+                            <BsFillPersonFill />
+                            {' ' + user.username}
+                        </li>
                     ))}
                 </ul>
             )}

--- a/src/client/src/components/AssignedUsers.tsx
+++ b/src/client/src/components/AssignedUsers.tsx
@@ -3,7 +3,7 @@ import { Spinner } from 'react-bootstrap';
 import { INode, UserData } from '../../../../types';
 import { getAssignedUsers } from '../services/assignmentService';
 import './styles/Sidebar.css';
-import { BsFillPeopleFill } from 'react-icons/bs';
+import { BsFillPersonFill } from 'react-icons/bs';
 
 interface assignedUsersProps {
     node: INode;
@@ -27,15 +27,12 @@ export const AssignedUsers = (props: assignedUsersProps): JSX.Element => {
 
     return assigned.length ? (
         <div>
-            <p>
-                <BsFillPeopleFill className="icon" /> Assigned users:
-            </p>
             {isLoading ? (
                 <Spinner animation="border" />
             ) : (
-                <ul>
+                <ul className='assigned-users-list'>
                     {assigned.map((user) => (
-                        <li>{user.username}</li>
+                        <li><BsFillPersonFill />{' ' + user.username}</li>
                     ))}
                 </ul>
             )}

--- a/src/client/src/components/EdgeDetail.tsx
+++ b/src/client/src/components/EdgeDetail.tsx
@@ -5,7 +5,7 @@ import './styles/Sidebar.css';
 import {
     BsClipboardCheck,
     BsExclamationCircle,
-    BsArrowDown
+    BsArrowDown,
 } from 'react-icons/bs';
 
 interface EdgeDetailProps {
@@ -32,12 +32,9 @@ export const EdgeDetail = (props: EdgeDetailProps): JSX.Element => {
             </h5>
             {source ? (
                 <>
-                    <h2>
-                        {source.label}
-                    </h2>
+                    <h2>{source.label}</h2>
                     <p>
-                        <BsClipboardCheck className="icon" />{' '}
-                        {source.status}
+                        <BsClipboardCheck className="icon" /> {source.status}
                     </p>
                     <p>
                         <BsExclamationCircle className="icon" />{' '}
@@ -46,15 +43,12 @@ export const EdgeDetail = (props: EdgeDetailProps): JSX.Element => {
                     {/* <p>ID: {source.id}</p> */}
                 </>
             ) : null}
-            <BsArrowDown className='icon' id='edge-detail-arrow' size='70'/>
+            <BsArrowDown className="icon" id="edge-detail-arrow" size="70" />
             {target ? (
                 <>
-                    <h2>
-                        {target.label}
-                    </h2>
+                    <h2>{target.label}</h2>
                     <p>
-                        <BsClipboardCheck className="icon" />{' '}
-                        {target.status}
+                        <BsClipboardCheck className="icon" /> {target.status}
                     </p>
                     <p>
                         <BsExclamationCircle className="icon" />{' '}

--- a/src/client/src/components/EdgeDetail.tsx
+++ b/src/client/src/components/EdgeDetail.tsx
@@ -5,7 +5,7 @@ import './styles/Sidebar.css';
 import {
     BsClipboardCheck,
     BsExclamationCircle,
-    BsCardHeading,
+    BsArrowDown
 } from 'react-icons/bs';
 
 interface EdgeDetailProps {
@@ -33,38 +33,31 @@ export const EdgeDetail = (props: EdgeDetailProps): JSX.Element => {
             {source ? (
                 <>
                     <h2>
-                        <BsCardHeading className="icon" />{' '}
-                        <b className="title">Source: </b>
                         {source.label}
                     </h2>
                     <p>
                         <BsClipboardCheck className="icon" />{' '}
-                        <b className="title">Status: </b>
                         {source.status}
                     </p>
                     <p>
                         <BsExclamationCircle className="icon" />{' '}
-                        <b className="title">Priority: </b>
                         {source.priority}
                     </p>
                     {/* <p>ID: {source.id}</p> */}
                 </>
             ) : null}
+            <BsArrowDown className='icon' id='edge-detail-arrow' size='70'/>
             {target ? (
                 <>
                     <h2>
-                        <BsCardHeading className="icon" />{' '}
-                        <b className="title">Target: </b>
                         {target.label}
                     </h2>
                     <p>
                         <BsClipboardCheck className="icon" />{' '}
-                        <b className="title">Status: </b>
                         {target.status}
                     </p>
                     <p>
                         <BsExclamationCircle className="icon" />{' '}
-                        <b className="title">Priority: </b>
                         {target.priority}
                     </p>
                     {/* <p>ID: {target.id}</p> */}

--- a/src/client/src/components/EdgeDetail.tsx
+++ b/src/client/src/components/EdgeDetail.tsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { Edge, Elements } from 'react-flow-renderer';
 import { IEdge, INode } from '../../../../types';
 import './styles/Sidebar.css';
-import {
-    BsClipboardCheck,
-    BsExclamationCircle,
-    BsArrowDown,
-} from 'react-icons/bs';
+import { BsClipboardCheck, BsExclamationCircle } from 'react-icons/bs';
+import { HiOutlineArrowNarrowDown } from 'react-icons/hi';
 
 interface EdgeDetailProps {
     element: Edge<IEdge>;
@@ -43,7 +40,11 @@ export const EdgeDetail = (props: EdgeDetailProps): JSX.Element => {
                     {/* <p>ID: {source.id}</p> */}
                 </>
             ) : null}
-            <BsArrowDown className="icon" id="edge-detail-arrow" size="70" />
+            <HiOutlineArrowNarrowDown
+                className="icon"
+                id="edge-detail-arrow"
+                size="70"
+            />
             {target ? (
                 <>
                     <h2>{target.label}</h2>

--- a/src/client/src/components/NodeDetail.tsx
+++ b/src/client/src/components/NodeDetail.tsx
@@ -46,12 +46,10 @@ export const NodeDetail = (props: NodeDetailProps): JSX.Element => {
                 )}
                 <p>
                     <BsClipboardCheck className="icon" />{' '}
-                    <b className="title">Status: </b>
                     {data.status}
                 </p>
                 <p>
                     <BsExclamationCircle className="icon" />{' '}
-                    <b className="title">Priority: </b>
                     {data.priority}
                 </p>
                 {/* <p>

--- a/src/client/src/components/NodeDetail.tsx
+++ b/src/client/src/components/NodeDetail.tsx
@@ -45,12 +45,10 @@ export const NodeDetail = (props: NodeDetailProps): JSX.Element => {
                     <p className="node-description">{data.description}</p>
                 )}
                 <p>
-                    <BsClipboardCheck className="icon" />{' '}
-                    {data.status}
+                    <BsClipboardCheck className="icon" /> {data.status}
                 </p>
                 <p>
-                    <BsExclamationCircle className="icon" />{' '}
-                    {data.priority}
+                    <BsExclamationCircle className="icon" /> {data.priority}
                 </p>
                 {/* <p>
                     <BsHash className="icon" /> <b className="title">ID: </b>


### PR DESCRIPTION
Removed sidebar labels for "status", "priority" and "assigned users". Also replaced "source" and "target" with an arrow in edge details.